### PR TITLE
"www.youtube.com" is removed from the list.

### DIFF
--- a/list/phish_domains.txt
+++ b/list/phish_domains.txt
@@ -5393,7 +5393,6 @@ www.xn--gmal-sya.com
 www.yalena.me
 www.yaqoobi.org
 www.yetpack.com
-www.youtube.com
 www.zjgsyds.cn
 www.zonasegurabeta.viabcp.transferencia.bcp.one21.in
 www1.micatd.co.jp.shanhujie.com


### PR DESCRIPTION
Today "www.youtube.com" is added to the list mistakenly. I've removed it.